### PR TITLE
prog8 code improvements

### DIFF
--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -3,13 +3,12 @@
 main {
 
     const uword rom = $e000
-    
+
     sub sumrom() -> uword {
         uword p = rom
         uword s = 0
-        ubyte page
         ubyte i
-        for page in 0 to $1f {
+        repeat $20 {
             for i in 0 to $ff {
                 s += @(p+i)
             }
@@ -17,7 +16,7 @@ main {
         }
         return s
     }
-    
+
     sub start() {
         benchcommon.begin()
         ubyte i
@@ -37,16 +36,16 @@ benchcommon {
     ubyte time_start0 = 0
     ubyte time_start1 = 0
     ubyte time_start2 = 0
-    
-    
+
+
     asmsub read_time () clobbers(A,X,Y) {
         %asm {{
-            jsr $FFDE 
+            jsr $FFDE
             sta last_time0
             stx last_time1
             sty last_time2
             rts
-        }}        
+        }}
     }
 
     sub begin() {
@@ -55,20 +54,20 @@ benchcommon {
         benchcommon.time_start1 = benchcommon.last_time1
         benchcommon.time_start2 = benchcommon.last_time2
     }
-    
+
     sub end() {
         benchcommon.read_time()
-        
+
         c64scr.print_ubhex(benchcommon.time_start2, false)
         c64scr.print_ubhex(benchcommon.time_start1, false)
         c64scr.print_ubhex(benchcommon.time_start0, false)
         c64.CHROUT('\n')
-        
+
         c64scr.print_ubhex(benchcommon.last_time2, false)
         c64scr.print_ubhex(benchcommon.last_time1, false)
         c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
-        
+
         c64scr.input_chars($c000)
     }
 }

--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -59,14 +59,14 @@ benchcommon {
     sub end() {
         benchcommon.read_time()
         
-        c64scr.print_ubhex(0, benchcommon.time_start2)
-        c64scr.print_ubhex(0, benchcommon.time_start1)
-        c64scr.print_ubhex(0, benchcommon.time_start0)
+        c64scr.print_ubhex(benchcommon.time_start2, false)
+        c64scr.print_ubhex(benchcommon.time_start1, false)
+        c64scr.print_ubhex(benchcommon.time_start0, false)
         c64.CHROUT('\n')
         
-        c64scr.print_ubhex(0, benchcommon.last_time2)
-        c64scr.print_ubhex(0, benchcommon.last_time1)
-        c64scr.print_ubhex(0, benchcommon.last_time0)
+        c64scr.print_ubhex(benchcommon.last_time2, false)
+        c64scr.print_ubhex(benchcommon.last_time1, false)
+        c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
         
         c64scr.input_chars($c000)

--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -68,7 +68,7 @@ benchcommon {
         c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
 
-        c64scr.input_chars($c000)
+        void c64scr.input_chars($c000)
     }
 }
 

--- a/6502/sieve-p8.p8
+++ b/6502/sieve-p8.p8
@@ -7,7 +7,6 @@ main {
     const uword Sieve = $4000
 
     sub sieve_round() {
-        uword Z
         uword S
         ubyte I = 2
         memset(Sieve, COUNT, 0)
@@ -83,7 +82,7 @@ benchcommon {
         c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
 
-        c64scr.input_chars($c000)
+        void c64scr.input_chars($c000)
     }
 }
 

--- a/6502/sieve-p8.p8
+++ b/6502/sieve-p8.p8
@@ -76,14 +76,14 @@ benchcommon {
     sub end() {
         benchcommon.read_time()
         
-        c64scr.print_ubhex(0, benchcommon.time_start2)
-        c64scr.print_ubhex(0, benchcommon.time_start1)
-        c64scr.print_ubhex(0, benchcommon.time_start0)
+        c64scr.print_ubhex(benchcommon.time_start2, false)
+        c64scr.print_ubhex(benchcommon.time_start1, false)
+        c64scr.print_ubhex(benchcommon.time_start0, false)
         c64.CHROUT('\n')
         
-        c64scr.print_ubhex(0, benchcommon.last_time2)
-        c64scr.print_ubhex(0, benchcommon.last_time1)
-        c64scr.print_ubhex(0, benchcommon.last_time0)
+        c64scr.print_ubhex(benchcommon.last_time2, false)
+        c64scr.print_ubhex(benchcommon.last_time1, false)
+        c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
         
         c64scr.input_chars($c000)

--- a/6502/sieve-p8.p8
+++ b/6502/sieve-p8.p8
@@ -5,42 +5,39 @@ main {
     const uword COUNT = 16384
     const uword SQRT_COUNT = 128
     const uword Sieve = $4000
-    
+
     sub sieve_round() {
         uword Z
         uword S
-        ubyte I
-        for Z in Sieve to (Sieve + COUNT - 1) {
-            @(Z) = 0
-        }
-        I = 2
-        while (I < SQRT_COUNT) {
-            if (@(Sieve + I) == 0) {
+        ubyte I = 2
+        memset(Sieve, COUNT, 0)
+        while I < SQRT_COUNT {
+            if @(Sieve + I) == 0 {
                 S = Sieve + (I << 1)
-                while (S < Sieve + COUNT) {
+                while S < Sieve + COUNT {
                     @(S) = 1
                     S += I
                 }
             }
-            I += 1
+            I ++
         }
     }
-    
+
     sub start() {
         benchcommon.begin()
-        
+
         sieve_round()
         sieve_round()
         sieve_round()
         sieve_round()
         sieve_round()
-        
+
         sieve_round()
         sieve_round()
         sieve_round()
         sieve_round()
         sieve_round()
-        
+
         benchcommon.end()
     }
 }
@@ -54,16 +51,16 @@ benchcommon {
     ubyte time_start0 = 0
     ubyte time_start1 = 0
     ubyte time_start2 = 0
-    
-    
+
+
     asmsub read_time () clobbers(A,X,Y) {
         %asm {{
-            jsr $FFDE 
+            jsr $FFDE
             sta last_time0
             stx last_time1
             sty last_time2
             rts
-        }}        
+        }}
     }
 
     sub begin() {
@@ -72,20 +69,20 @@ benchcommon {
         benchcommon.time_start1 = benchcommon.last_time1
         benchcommon.time_start2 = benchcommon.last_time2
     }
-    
+
     sub end() {
         benchcommon.read_time()
-        
+
         c64scr.print_ubhex(benchcommon.time_start2, false)
         c64scr.print_ubhex(benchcommon.time_start1, false)
         c64scr.print_ubhex(benchcommon.time_start0, false)
         c64.CHROUT('\n')
-        
+
         c64scr.print_ubhex(benchcommon.last_time2, false)
         c64scr.print_ubhex(benchcommon.last_time1, false)
         c64scr.print_ubhex(benchcommon.last_time0, false)
         c64.CHROUT('\n')
-        
+
         c64scr.input_chars($c000)
     }
 }


### PR DESCRIPTION
Hi, I've improved the prog8 code somewhat (fixed call arguments ordering bug for print_ubhex, made the code a bit more idiomatic prog8, and fixed compiler warnings).

If you merge this, please also re-run the benchmarks with Prog8 v3.1 as there have been several important compiler improvements.

Finally, you mention "Due to bugs in Prog8, instead of calculating the time, start timestamp and end timestamp are displayed." can you please let me know what those bugs are? If they're still present could you please open an issue on prog8's github?  Appreciated :) 