### PR TITLE
added prog8 plasma benchmark

### DIFF
--- a/6502/plasma-p8.p8
+++ b/6502/plasma-p8.p8
@@ -1,0 +1,137 @@
+%import c64lib
+
+
+;/*****************************************************************************\
+;** plasma test program for cc65.                                             **
+;**                                                                           **
+;** (w)2001 by groepaz/hitmen                                                 **
+;**                                                                           **
+;** Cleanup and porting by Ullrich von Bassewitz.                             **
+;** Converted to prog8 by Irmen de Jong                                       **
+;**                                                                           **
+;\*****************************************************************************/
+
+main {
+    const uword SCREEN1 = $E000
+    const uword SCREEN2 = $E400
+    const uword CHARSET = $E800
+
+    const ubyte PAGE1 = ((SCREEN1 >> 6) & $F0) | ((CHARSET >> 10) & $0E)
+    const ubyte PAGE2 = ((SCREEN2 >> 6) & $F0) | ((CHARSET >> 10) & $0E)
+
+    sub start() {
+        c64.COLOR = 1
+        c64scr.print("creating charset...\n")
+        makechar()
+
+        benchcommon.begin()
+
+        ubyte block = c64.CIA2PRA
+        ubyte v = c64.VMCSB
+        c64.CIA2PRA = (block & $FC) | (lsb(SCREEN1 >> 14) ^ $03)
+
+        repeat 500 {
+            doplasma(SCREEN1)
+            c64.VMCSB = PAGE1
+            doplasma(SCREEN2)
+            c64.VMCSB = PAGE2
+        }
+
+        ; restore screen
+        c64.VMCSB = v
+        c64.CIA2PRA = block
+
+        c64scr.print("done!\n")
+        benchcommon.end()
+    }
+
+    ; several variables outside of doplasma to make them retain their value
+    ubyte c1A
+    ubyte c1B
+    ubyte c2A
+    ubyte c2B
+
+    sub doplasma(uword screen) {
+        ubyte[40] xbuf
+        ubyte[25] ybuf
+        ubyte c1a = c1A
+        ubyte c1b = c1B
+        ubyte c2a = c2A
+        ubyte c2b = c2B
+        ubyte @zp i
+        ubyte @zp ii
+
+        for ii in 0 to 24 {
+            ybuf[ii] = sin8u(c1a) + sin8u(c1b)
+            c1a += 4
+            c1b += 9
+        }
+        c1A += 3
+        c1B -= 5
+        for i in 0 to 39 {
+            xbuf[i] = sin8u(c2a) + sin8u(c2b)
+            c2a += 3
+            c2b += 7
+        }
+        c2A += 2
+        c2B -= 3
+        for ii in 0 to 24 {
+            for i in 0 to 39 {
+                @(screen) = xbuf[i] + ybuf[ii]
+                screen++
+            }
+        }
+    }
+
+    sub makechar() {
+
+        ubyte[8] bittab = [ $01, $02, $04, $08, $10, $20, $40, $80 ]
+        ubyte c
+        for c in 0 to 255 {
+            ubyte @zp s = sin8u(c)
+            ubyte i
+            for i in 0 to 7 {
+                ubyte b=0
+                ubyte @zp ii
+                for ii in 0 to 7 {
+                    ; use 16 bit rng for a bit more randomness instead of the 8-bit rng
+                    if lsb(rndw()) > s {
+                        b |= bittab[ii]
+                    }
+                }
+                @(CHARSET + i + c*8.w) = b
+            }
+        }
+    }
+}
+
+
+
+benchcommon {
+    uword last_time = 0
+    uword time_start = 0
+
+
+    asmsub read_time () clobbers(A,X,Y) {
+        %asm {{
+            jsr $FFDE
+            sta last_time
+            stx last_time+1
+            rts
+        }}
+    }
+
+    sub begin() {
+        benchcommon.read_time()
+        benchcommon.time_start = benchcommon.last_time
+    }
+
+    sub end() {
+        benchcommon.read_time()
+
+        c64scr.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
+        c64.CHROUT('\n')
+
+        void c64scr.input_chars($c000)
+    }
+}


### PR DESCRIPTION
Here is my prog8 version of the plasma benchmark.
The conversion went pretty smooth and the resulting code looks kinda nice I think.

Note: it only compiles correctly with the latest prog8 version (3.2) because I ran into a few compiler bugs that had to be fixed.
Also, 3.2 has some significant improvements in the code generator, making the resulting programs a lot faster than before. Can you please also re-run the other benchmarks with this new version? Much obliged.


background:
The short loops in the plasma code are great for prog8 but I'm struggling with generating efficient code for expression evaluations. Most of that is done on a slow, separate evaluation stack. It does keep my code generator relatively simple and compact but the resulting assembly code is bulky and thus rather slow.  I don't know  how to solve this yet.