### PR TITLE
updated prog8 benchmarks to new prog8 4.0 release

### DIFF
--- a/6502/plasma-p8.p8
+++ b/6502/plasma-p8.p8
@@ -1,4 +1,4 @@
-%import c64lib
+%import c64textio
 
 
 ;/*****************************************************************************\
@@ -21,7 +21,7 @@ main {
 
     sub start() {
         c64.COLOR = 1
-        c64scr.print("creating charset...\n")
+        txt.print("creating charset...\n")
         makechar()
 
         benchcommon.begin()
@@ -41,7 +41,7 @@ main {
         c64.VMCSB = v
         c64.CIA2PRA = block
 
-        c64scr.print("done!\n")
+        txt.print("done!\n")
         benchcommon.end()
     }
 
@@ -130,9 +130,9 @@ benchcommon {
     sub end() {
         benchcommon.read_time()
 
-        c64scr.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
+        txt.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
         c64.CHROUT('\n')
 
-        void c64scr.input_chars($c000)
+        void txt.input_chars($c000)
     }
 }

--- a/6502/plasma-p8.p8
+++ b/6502/plasma-p8.p8
@@ -61,22 +61,23 @@ main {
         ubyte @zp i
         ubyte @zp ii
 
-        for ii in 0 to 24 {
+        for ii in 24 downto 0 {
             ybuf[ii] = sin8u(c1a) + sin8u(c1b)
             c1a += 4
             c1b += 9
         }
         c1A += 3
         c1B -= 5
-        for i in 0 to 39 {
+        for i in 39 downto 0 {
             xbuf[i] = sin8u(c2a) + sin8u(c2b)
             c2a += 3
             c2b += 7
         }
         c2A += 2
         c2B -= 3
-        for ii in 0 to 24 {
-            for i in 0 to 39 {
+
+        for ii in 24 downto 0 {
+            for i in 39 downto 0 {
                 @(screen) = xbuf[i] + ybuf[ii]
                 screen++
             }

--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -7,12 +7,9 @@ main {
     sub sumrom() -> uword {
         uword p = rom
         uword s = 0
-        ubyte i
-        repeat $20 {
-            for i in 0 to $ff {
-                s += @(p+i)
-            }
-            p += $100
+        while(p) {
+            s += @(p)
+            p++
         }
         return s
     }

--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -1,4 +1,4 @@
-%import c64utils
+%import c64textio
 
 main {
 
@@ -18,7 +18,7 @@ main {
         benchcommon.begin()
         ubyte i
         for i in 0 to 5 {
-            c64scr.print_uw(sumrom())
+            txt.print_uw(sumrom())
             c64.CHROUT('\n')
         }
         benchcommon.end()
@@ -48,10 +48,10 @@ benchcommon {
     sub end() {
         benchcommon.read_time()
 
-        c64scr.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
+        txt.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
         c64.CHROUT('\n')
 
-        void c64scr.input_chars($c000)
+        void txt.input_chars($c000)
     }
 }
 

--- a/6502/sieve-p8.p8
+++ b/6502/sieve-p8.p8
@@ -1,4 +1,4 @@
-%import c64utils
+%import c64textio
 
 main {
 
@@ -65,10 +65,10 @@ benchcommon {
     sub end() {
         benchcommon.read_time()
 
-        c64scr.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
+        txt.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
         c64.CHROUT('\n')
 
-        void c64scr.input_chars($c000)
+        void txt.input_chars($c000)
     }
 }
 


### PR DESCRIPTION
I've just released a new version 4.0 of Prog8. Significant changes are:
- library API has changed which requires code modifications to use a different import and the txt. namespace
- significant performance improvements to generated code (sometimes up to 50%)

This pull request contains the required code changes for the benchmark programs to be compatible with the new prog8 version, but I've also made a few small other tweaks (such as removing an unneeded nested loop, which makes it more similar to the C code too)

If you merge this, please also re-run the benchmarks with Prog8 v4.0.  You should observe quite significant improvements.

Thank you!

p.s. I won't be bothering you again anytime soon I think, because my focus for prog8 will no longer be on performance improvements for the near future 