### PR TITLE
Updates to Prog8 benchmark programs for recent Prog8 version

### DIFF
--- a/6502/README.md
+++ b/6502/README.md
@@ -40,7 +40,7 @@ Remarks:
 
 * I haven't been able to make Atalan compile benchmarks other than `sieve` and `romsum` without crashing.
 
-* Language limitations make it very hard, if not impossible, to implement `fib` in KickC and `fib` and `linkedlist` in Prog8.
+* Language limitations make it very hard, if not impossible, to implement `fib` in KickC and `fib` in Prog8.
 
 * BASIC-BOSS was included as a curiosity, to compare the 1988 technology with more modern solutions. Due to various limitations, only the `sieve` benchmark was implemented and it displays the timing in decimal, not hexadecimal.
 
@@ -146,7 +146,7 @@ Results:
 
 ### Benchmark `linkedlist`
 
-Source: [`linkedlist.c`](./linkedlist.c), [`linkedlist.mfk`](./linkedlist.mfk), [`linkedlist-kc.kc`](./linkedlist-kc.kc)
+Source: [`linkedlist.c`](./linkedlist.c), [`linkedlist.mfk`](./linkedlist.mfk), [`linkedlist-kc.kc`](./linkedlist-kc.kc) [`linkedlist-p8.p8`](./linkedlist-p8.p8)
 
 The benchmark creates a single-linked list with 3000 entries, with a 16-bit integer at each node, and then traverses the list and sums all the values together. It does it five times, for more precise results.
  

--- a/6502/linkedlist-p8.p8
+++ b/6502/linkedlist-p8.p8
@@ -1,0 +1,95 @@
+%import textio
+
+; note: requires at least Prog8 6.1 to compile
+
+main {
+    struct Node {
+        uword next
+        uword value
+    }
+
+    uword  free
+    uword  root
+    uword  heap
+
+    sub start() {
+        heap = memory("heap", 4000*sizeof(Node))
+
+        benchcommon.begin()
+        repeat 5 {
+            init()
+            uword i
+            for i in 0 to 2999
+                prepend(i)
+
+            txt.chrout(lsb(calc_sum()))
+        }
+        txt.nl()
+        benchcommon.end()
+    }
+
+    sub init() {
+        free = 0
+        root = 0
+    }
+
+    sub alloc() -> uword {
+        uword result = free
+        result *= sizeof(Node)
+        result += heap
+        free++
+        return result
+    }
+
+    sub prepend(uword x) {
+        uword new = alloc()
+
+        ; prog8 doesn't yet support typed pointers and corresponding pointer dereferencing
+        ; so instead we write directly into the memory locations
+        pokew(new, root)
+        pokew(new+2, x)
+        root = new
+    }
+
+    sub calc_sum() -> uword {
+        uword current = root
+        uword s = 0
+        while current {
+            ; prog8 doesn't yet support typed pointers and corresponding pointer dereferencing
+            ; so instead we read directly from the memory locations
+            s += peekw(current+2)
+            current = peekw(current)
+        }
+        return s
+    }
+}
+
+
+benchcommon {
+    uword last_time = 0
+    uword time_start = 0
+
+
+    asmsub read_time () clobbers(A,X,Y) {
+        %asm {{
+            jsr $FFDE
+            sta last_time
+            stx last_time+1
+            rts
+        }}
+    }
+
+    sub begin() {
+        benchcommon.read_time()
+        benchcommon.time_start = benchcommon.last_time
+    }
+
+    sub end() {
+        benchcommon.read_time()
+
+        txt.print_uwhex(benchcommon.last_time-benchcommon.time_start, false)
+        txt.chrout('\n')
+
+        void txt.input_chars($c000)
+    }
+}

--- a/6502/linkedlist-p8.p8
+++ b/6502/linkedlist-p8.p8
@@ -3,17 +3,12 @@
 ; note: requires at least Prog8 6.1 to compile
 
 main {
-    struct Node {
-        uword next
-        uword value
-    }
-
     uword  free
     uword  root
     uword  heap
 
     sub start() {
-        heap = memory("heap", 4000*sizeof(Node))
+        heap = memory("heap", 4000*4)
 
         benchcommon.begin()
         repeat 5 {
@@ -35,7 +30,7 @@ main {
 
     sub alloc() -> uword {
         uword result = free
-        result *= sizeof(Node)
+        result *= 4
         result += heap
         free++
         return result

--- a/6502/plasma-p8.p8
+++ b/6502/plasma-p8.p8
@@ -2,7 +2,7 @@
 
 ;  converted from plasma test program for cc65.
 ;  which is (w)2001 by groepaz/hitmen
-; 
+;
 ;  Cleanup and porting to C by Ullrich von Bassewitz.
 ;  Converted to prog8 by Irmen de Jong.
 
@@ -76,9 +76,9 @@ main {
         for ii in 24 downto 0 {
             for i in 39 downto 0 {
                 cc = xbuf[i] + ybuf[ii]
-                @(screen) = cc
-                screen++
+                @(screen+i) = cc
             }
+            screen += 40
         }
     }
 

--- a/6502/romsum-p8.p8
+++ b/6502/romsum-p8.p8
@@ -7,9 +7,12 @@ main {
     sub sumrom() -> uword {
         uword p = rom
         uword s = 0
-        while p {
-            s += @(p)
-            p++
+        repeat $100-$e0 {
+            ubyte ix
+            for ix in 0 to 255 {
+                s += @(p+ix)
+            }
+            p += $100
         }
         return s
     }

--- a/6502/sieve-p8.p8
+++ b/6502/sieve-p8.p8
@@ -9,7 +9,7 @@ main {
     sub sieve_round() {
         uword S
         ubyte I = 2
-        memset(Sieve, COUNT, 0)
+        sys.memset(Sieve, COUNT, 0)
         ; txt.print("primes: ")
         while I < SQRT_COUNT {
             if @(Sieve + I) == 0 {


### PR DESCRIPTION
Prog8 6.2 was just released and since 6.0, contains some changes in the language and the libraries it provides.
I've updated the prog8 benchmark programs to reflect those.

Also I've implemented the _linkedlist_ example in Prog8, it was missing until now. Prog8 scores around 270 which places it between millfork and kickc I think

Request to re-run the (now four) prog8 benchmark programs with most recent prog8 release to update the numbers (they've improved substantially in with prog8 6.x version) is here: #8 